### PR TITLE
Update link to XBlocks tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ First, grab the source code for XBlock at https://github.com/edx/XBlock :
 
     $ git clone https://github.com/edx/XBlock.git
     $ cd XBlock
-    $ gvim README.rst
 
 Follow the instructions in `README.md` to get the workbench server up and running. Once you're done, you should be able to visit http://127.0.0.1:8000/
 
 Tutorial
 --------
 
-For the rest of the tutorial, continue to http://antoviaque.org/docs/edx/xblock/tutorial.html
-
+For the rest of the tutorial, continue to http://opencraft.com/doc/edx/xblock/tutorial.html


### PR DESCRIPTION
The tutorial is now at http://opencraft.com/doc/edx/xblock/tutorial.html.
